### PR TITLE
Implement round system with countdown

### DIFF
--- a/BankGame/client/package.json
+++ b/BankGame/client/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "bankgame-client",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
+    "socket.io-client": "^4.0.0"
+  }
+}

--- a/BankGame/client/src/App.jsx
+++ b/BankGame/client/src/App.jsx
@@ -1,0 +1,28 @@
+import React, { useState } from 'react';
+import JoinForm from './components/JoinForm.jsx';
+import Lobby from './components/Lobby.jsx';
+
+export default function App() {
+  const [joined, setJoined] = useState(false);
+  const [username, setUsername] = useState('');
+  const [gameCode, setGameCode] = useState('');
+  const [isHost, setIsHost] = useState(false);
+
+  const handleJoin = (name, code, host) => {
+    setUsername(name);
+    setGameCode(code);
+    setIsHost(host);
+    setJoined(true);
+  };
+
+  return (
+    <div>
+      <h1>BankGame</h1>
+      {joined ? (
+        <Lobby username={username} code={gameCode} isHost={isHost} />
+      ) : (
+        <JoinForm onJoin={handleJoin} />
+      )}
+    </div>
+  );
+}

--- a/BankGame/client/src/components/JoinForm.jsx
+++ b/BankGame/client/src/components/JoinForm.jsx
@@ -1,0 +1,89 @@
+import React, { useState, useEffect } from 'react';
+import socket from '../socket.js';
+
+export default function JoinForm({ onJoin }) {
+  const [name, setName] = useState('');
+  const [code, setCode] = useState('');
+  const [error, setError] = useState('');
+  const [waiting, setWaiting] = useState(false);
+  const [hostMode, setHostMode] = useState(false);
+  const [joinedGame, setJoinedGame] = useState(false);
+
+  useEffect(() => {
+    function handleGameCreated(gameCode) {
+      setCode(gameCode);
+      setHostMode(true);
+      socket.emit('joinGame', { name, code: gameCode });
+      onJoin(name, gameCode, true);
+      setJoinedGame(true);
+      setWaiting(false);
+    }
+
+    function handlePlayerJoined({ players, code: joinedCode }) {
+      if (!joinedGame && joinedCode === code && players.includes(name)) {
+        onJoin(name, joinedCode, hostMode);
+        setJoinedGame(true);
+        setWaiting(false);
+      }
+    }
+
+    function handleJoinFailed() {
+      setError('Failed to join game');
+      setWaiting(false);
+      setJoinedGame(false);
+    }
+
+    socket.on('gameCreated', handleGameCreated);
+    socket.on('playerJoined', handlePlayerJoined);
+    socket.on('joinFailed', handleJoinFailed);
+    return () => {
+      socket.off('gameCreated', handleGameCreated);
+      socket.off('playerJoined', handlePlayerJoined);
+      socket.off('joinFailed', handleJoinFailed);
+    };
+  }, [name, code, hostMode, joinedGame, onJoin]);
+
+  const create = (e) => {
+    e.preventDefault();
+    if (!name) {
+      setError('Enter a name');
+      return;
+    }
+    setWaiting(true);
+    setJoinedGame(false);
+    setHostMode(true);
+    socket.emit('createGame', { name });
+  };
+
+  const join = (e) => {
+    e.preventDefault();
+    if (!name || !code) {
+      setError('Enter name and code');
+      return;
+    }
+    setWaiting(true);
+    setJoinedGame(false);
+    setHostMode(false);
+    socket.emit('joinGame', { name, code });
+  };
+
+  return (
+    <div>
+      <div>{error}</div>
+      <input
+        type="text"
+        placeholder="Name"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+      />
+      <input
+        type="text"
+        placeholder="Game Code"
+        value={code}
+        onChange={(e) => setCode(e.target.value.toUpperCase())}
+      />
+      <button onClick={create} disabled={waiting}>Create Game</button>
+      <button onClick={join} disabled={waiting}>Join Game</button>
+    </div>
+  );
+}

--- a/BankGame/client/src/components/Lobby.jsx
+++ b/BankGame/client/src/components/Lobby.jsx
@@ -1,0 +1,66 @@
+import React, { useState, useEffect } from 'react';
+import socket from '../socket.js';
+
+export default function Lobby({ username, code, isHost }) {
+  const [players, setPlayers] = useState([]);
+  const [countdown, setCountdown] = useState(null);
+  const [result, setResult] = useState(null);
+
+  useEffect(() => {
+    function handlePlayerJoined({ players: list, code: joinedCode }) {
+      if (joinedCode === code) {
+        setPlayers(list);
+      }
+    }
+    function handleCountdownTick({ secondsLeft }) {
+      setCountdown(secondsLeft);
+    }
+
+    function handleRoundResult(res) {
+      setCountdown(null);
+      setResult(res);
+    }
+
+    socket.on('playerJoined', handlePlayerJoined);
+    socket.on('countdownTick', handleCountdownTick);
+    socket.on('roundResult', handleRoundResult);
+    return () => {
+      socket.off('playerJoined', handlePlayerJoined);
+      socket.off('countdownTick', handleCountdownTick);
+      socket.off('roundResult', handleRoundResult);
+    };
+  }, [code]);
+
+  const start = () => {
+    socket.emit('startRound');
+  };
+
+  return (
+    <div>
+      <h2>Game Code: {code}</h2>
+      <p>You are: {username}</p>
+      <h3>Players</h3>
+      <ul>
+        {players.map((p, i) => (
+          <li key={i}>{p}</li>
+        ))}
+      </ul>
+      {countdown !== null && <p>Round starting in: {countdown}</p>}
+      {result && (
+        <div>
+          <h4>Round {result.round} Results</h4>
+          <ul>
+            {result.rolls.map((r) => (
+              <li key={r.name}>
+                {r.name}: {r.roll}
+                {r.name === result.banker ? ' (banker)' : ''}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+      {isHost && <button onClick={start}>Start Round</button>}
+    </div>
+  );
+}
+

--- a/BankGame/client/src/main.jsx
+++ b/BankGame/client/src/main.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App.jsx';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/BankGame/client/src/socket.js
+++ b/BankGame/client/src/socket.js
@@ -1,0 +1,6 @@
+import { io } from 'socket.io-client';
+
+const URL = import.meta.env.VITE_SERVER_URL || 'http://localhost:3000';
+const socket = io(URL);
+
+export default socket;

--- a/BankGame/client/vite.config.js
+++ b/BankGame/client/vite.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+  },
+});

--- a/BankGame/server/game/GameState.js
+++ b/BankGame/server/game/GameState.js
@@ -1,0 +1,33 @@
+export default class GameState {
+  constructor() {
+    this.players = []; // array of { name, socketId }
+    this.host = null; // socket id of host
+    this.round = 0;
+    this.status = 'waiting';
+    this.timer = null; // countdown timer reference
+  }
+
+  addPlayer(name, socketId) {
+    if (!this.players.some((p) => p.socketId === socketId)) {
+      this.players.push({ name, socketId });
+      if (!this.host) {
+        this.host = socketId;
+      }
+    }
+  }
+
+  removePlayer(socketId) {
+    this.players = this.players.filter((p) => p.socketId !== socketId);
+    if (this.host === socketId) {
+      this.host = this.players[0] ? this.players[0].socketId : null;
+    }
+  }
+
+  getPlayerNames() {
+    return this.players.map((p) => p.name);
+  }
+
+  isHost(socketId) {
+    return this.host === socketId;
+  }
+}

--- a/BankGame/server/index.js
+++ b/BankGame/server/index.js
@@ -1,0 +1,110 @@
+import express from 'express';
+import http from 'http';
+import { Server } from 'socket.io';
+import cors from 'cors';
+import GameState from './game/GameState.js';
+import { generateGameCode } from './utils/generateGameCode.js';
+
+const PORT = 3000;
+const app = express();
+app.use(cors({ origin: 'http://localhost:5173' }));
+
+const server = http.createServer(app);
+const io = new Server(server, {
+  cors: {
+    origin: 'http://localhost:5173',
+  },
+});
+
+const games = {};
+
+function rollAndBroadcast(game, code) {
+  game.status = 'rolling';
+  const rolls = game.players.map((p) => ({
+    name: p.name,
+    roll: Math.floor(Math.random() * 6) + 1,
+  }));
+  const banker = rolls[Math.floor(Math.random() * rolls.length)].name;
+  game.round += 1;
+  game.status = 'waiting';
+  io.to(code).emit('roundResult', { round: game.round, rolls, banker });
+}
+
+io.on('connection', (socket) => {
+  console.log(`Socket connected: ${socket.id}`);
+
+  socket.on('createGame', () => {
+    let code;
+    do {
+      code = generateGameCode();
+    } while (games[code]);
+    games[code] = new GameState();
+    socket.emit('gameCreated', code);
+    console.log(`Game created with code ${code}`);
+  });
+
+  socket.on('joinGame', ({ name, code }) => {
+    const game = games[code];
+    if (game) {
+      socket.data.name = name;
+      socket.data.code = code;
+      game.addPlayer(name, socket.id);
+      socket.join(code);
+      io.to(code).emit('playerJoined', { players: game.getPlayerNames(), code });
+      console.log(`${name} joined game ${code}`);
+    } else {
+      socket.emit('joinFailed');
+      console.log(`Join failed for code ${code}`);
+    }
+  });
+
+  socket.on('startRound', () => {
+    const { code } = socket.data || {};
+    const game = games[code];
+    if (!game || !game.isHost(socket.id) || game.status !== 'waiting') {
+      return;
+    }
+
+    if (game.timer) {
+      clearInterval(game.timer);
+      game.timer = null;
+    }
+
+    const COUNTDOWN = 5;
+    let remaining = COUNTDOWN;
+    game.status = 'countdown';
+    io.to(code).emit('countdownTick', { secondsLeft: remaining });
+    game.timer = setInterval(() => {
+      remaining -= 1;
+      if (remaining > 0) {
+        io.to(code).emit('countdownTick', { secondsLeft: remaining });
+      } else {
+        clearInterval(game.timer);
+        game.timer = null;
+        rollAndBroadcast(game, code);
+      }
+    }, 1000);
+  });
+
+  socket.on('disconnect', () => {
+    const { code, name } = socket.data || {};
+    if (code && games[code]) {
+      const game = games[code];
+      game.removePlayer(socket.id);
+      io.to(code).emit('playerJoined', { players: game.getPlayerNames(), code });
+      console.log(`${name} left game ${code}`);
+      if (game.getPlayerNames().length === 0) {
+        delete games[code];
+      }
+    }
+    console.log(`Socket disconnected: ${socket.id}`);
+  });
+});
+
+app.get('/', (req, res) => {
+  res.send('BankGame Server');
+});
+
+server.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});

--- a/BankGame/server/package.json
+++ b/BankGame/server/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "bankgame-server",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "express": "^4.0.0",
+    "socket.io": "^4.0.0",
+    "cors": "^2.0.0"
+  }
+}

--- a/BankGame/server/utils/generateGameCode.js
+++ b/BankGame/server/utils/generateGameCode.js
@@ -1,0 +1,8 @@
+export function generateGameCode(length = 6) {
+  const chars = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789';
+  let code = '';
+  for (let i = 0; i < length; i++) {
+    code += chars[Math.floor(Math.random() * chars.length)];
+  }
+  return code;
+}


### PR DESCRIPTION
## Summary
- track host and players in GameState
- implement round countdown and dice roll logic on server
- broadcast countdown ticks and round results
- update Lobby UI to display countdown, results, and host-triggered start button

## Testing
- `npm install` in `client` *(fails: 403 Forbidden - registry.npmjs.org)*
- `npm install` in `server` *(fails: 403 Forbidden - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_686c5769f4308322a0b6c6526d99fb27